### PR TITLE
feat: Enable build & run compute from scripts

### DIFF
--- a/compute/build_compute.sh
+++ b/compute/build_compute.sh
@@ -1,0 +1,7 @@
+#!/bin/bash
+# file: build_compute.sh
+# info: builds a docker compute image 
+IMAGE_NAME=s3p/compute:latest
+
+docker build -t ${IMAGE_NAME} \
+    --build-arg http_proxy=$http_proxy --build-arg https_proxy=$https_proxy .

--- a/compute/dockerfile
+++ b/compute/dockerfile
@@ -1,30 +1,32 @@
 FROM 		ubuntu:14.04
 MAINTAINER	OpenDaylight Int/Test Project Team <integration-dev@lists.opendaylight.org>
 
-ENV    		PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
+ENV		PATH="/usr/local/sbin:/usr/local/bin:/usr/sbin:/usr/bin:/sbin:/bin"
 
 # Add stack user
-RUN 		groupadd stack && \
-		useradd -g stack -s /bin/bash -m stack && \
-		echo "stack ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
+RUN		groupadd stack && \
+			useradd -g stack -s /bin/bash -m stack && \
+			echo "stack ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers
 
 # Install git and sshd
-RUN 		apt-get update && \
-		apt-get install -y --no-install-recommends git \
-		openssh-server ca-certificates openvswitch-common \
-		openvswitch-switch dbus && \ 
-		rm -rf /var/lib/apt/lists/*
+RUN 	apt-get update && \
+			apt-get install -y --no-install-recommends git \
+			openssh-server ca-certificates openvswitch-common \
+			openvswitch-switch dbus && \ 
+			rm -rf /var/lib/apt/lists/*
 
 # Get devstack
-USER 		stack
-RUN 		git clone https://git.openstack.org/openstack-dev/devstack \
-		/home/stack/devstack
+USER	stack
+RUN		git clone https://git.openstack.org/openstack-dev/devstack \
+			/home/stack/devstack
 # Copy and chown local.conf to stack
-COPY 		local.conf /home/stack/devstack/
-RUN 		chown stack:stack /home/stack/devstack/local.conf
+COPY 	local.conf /home/stack/devstack/
+RUN 	sudo chown stack:stack /home/stack/devstack/local.conf
 
 # Copy start.sh and chown to stack
-COPY            start.sh /home/stack/
-RUN		sudo chown -R stack:stack /home/stack/start.sh
+COPY	start.sh /home/stack/
+RUN		sudo chown stack:stack /home/stack/start.sh && chmod 766 /home/stack/start.sh
 
-CMD ["/start.sh"]
+CMD		["/start.sh"]
+
+# vim: set ft=dockerfile noet sw=4 ts=4 :

--- a/compute/run_compute.sh
+++ b/compute/run_compute.sh
@@ -1,0 +1,21 @@
+#!/bin/bash
+# file: ./run_compute.sh
+# info: spawns a docker compute image 
+# dependencies: assumes proxy variables are defined in the local environment
+
+HOST_ID=01
+COMP_ID=01
+BASE_IMAGE=s3p/compute:latest
+COMMAND="/home/stack/start.sh"
+
+if [ -z "$1" ] ; then
+    COMMAND="$1"
+fi
+
+NAME=compute.${HOST_ID}.${COMP_ID}
+
+docker run -it --name ${NAME} --hostname ${NAME} \
+    --env http_proxy=$http_proxy --env https_proxy=$https_proxy \
+    $BASE_IMAGE \
+    $COMMAND
+

--- a/compute/start.sh
+++ b/compute/start.sh
@@ -17,8 +17,8 @@ sudo service openvswitch-switch start
 echo -e $STACK_PASS | sudo passwd stack
 
 # Add/Configure local.conf - requires use of 'docker run -v :/home/stack/mnt
-sudo chown stack:stack /home/stack/mnt/local.conf
-cp /home/stack/mnt/local.conf /home/stack/devstack/local.conf
+sudo chmod 766 /home/stack/local.conf
+cp /home/stack/local.conf /home/stack/devstack/local.conf
 
 sed -i "s/SERVICE_HOST=/SERVICE_HOST=$SERV_HOST/" /home/stack/devstack/local.conf
 


### PR DESCRIPTION
Scripts will build the compute container and run it.
Some modificatons to enable stacking in container.
Fixed tabs on dockerfile.
TODO: stacking shows issues with bridges
TODO: populate container name from IDs of running containers